### PR TITLE
fix: compatible with go 1.16

### DIFF
--- a/cslb/group.go
+++ b/cslb/group.go
@@ -1,13 +1,13 @@
 package cslb
 
 import (
-	"math"
+	"math/bits"
 	"sync"
 	"sync/atomic"
 )
 
 const (
-	NodeCountUnlimited = math.MaxInt
+	NodeCountUnlimited = (1 << bits.UintSize) / 2 - 1
 )
 
 type Group struct {

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
go 1.16 github.com/XiaoMi/go-fds/blob/master/cslb/group.go:10:23: undefined: math.MaxInt